### PR TITLE
fix multiply energy match bug

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -3,7 +3,7 @@ local function MultiplyEnergy(src, multiplier)
   if type(src) ~= "string" then
     return src
   end
-  local EnergyNum, EnergyUnit = src:match("(%d+)(%a+)")
+  local EnergyNum, EnergyUnit = src:match("(%d+%.?%d*)(%a+)")
   return EnergyNum * multiplier .. EnergyUnit
 end
 -- if settings.startup["enable-for-all-tiers"].value == true then  


### PR DESCRIPTION
Patch to fix energy settings issues.

New Settings adjustments are not working out to be in line with vanilla power ratios:
vanilla robots:
1.5mj energy capacity
(logistic)
18kW max consumption,
15kW move consumption,
(construction)
21kW max consumption,
18kW move consumption.

v0.18.2 mod settings:
5mJ  energy capacity,
(logistic)
315kW max consumption,
15kW move consumption,
(construct)
318 kW max consumption,
18 kW move consumption.

If you compare the unmodified to modified data structure you can see that energy per tick is not being set properly:
unmodified:
{
  ["logistic-robot"] = {
    energy_per_move = "5kJ",
    energy_per_tick = "0.05kJ",
    max_energy = "1.5MJ",
    max_health = 100,
    max_payload_size = 1,
    max_to_charge = 0.95,
    min_to_charge = 0.2,
    minable = {
      mining_time = 0.1,
      result = "logistic-robot"
    },
    name = "logistic-robot",
  }
}
{
  ["construction-robot"] = {
    energy_per_move = "5kJ",
    energy_per_tick = "0.05kJ",
    max_energy = "1.5MJ",
    max_health = 100,
    max_payload_size = 1,
    max_to_charge = 0.95,
    min_to_charge = 0.2,
    minable = {
      mining_time = 0.1,
      result = "construction-robot"
    },
    name = "construction-robot",
  }
}

modified:
{
  ["logistic-robot"] = {
    energy_per_move = "5kJ",
    energy_per_tick = "5kJ",
    max_energy = "5MJ",
    max_health = 100,
    max_payload_size = 1,
    max_to_charge = 0.95,
    min_to_charge = 0.2,
    minable = {
      mining_time = 0.1,
      result = "logistic-robot"
    },
    name = "logistic-robot",
  }
}
{
  ["construction-robot"] = {
    energy_per_move = "5kJ",
    energy_per_tick = "5kJ",
    max_energy = "5MJ",
    max_health = 100,
    max_payload_size = 1,
    max_to_charge = 0.95,
    min_to_charge = 0.2,
    minable = {
      mining_time = 0.1,
      result = "construction-robot"
    },
    name = "construction-robot",
  }
}

   4.309 Script @__robotworld-continued__/data-final-fixes.lua:7: SRC: 1.5MJMATCHED: 5MJ
   4.309 Script @__robotworld-continued__/data-final-fixes.lua:7: SRC: 5kJMATCHED: 5kJ
   4.309 Script @__robotworld-continued__/data-final-fixes.lua:7: SRC: 0.05kJMATCHED: 05kJ
   4.309 Script @__robotworld-continued__/data-final-fixes.lua:7: SRC: 1.5MJMATCHED: 5MJ
   4.309 Script @__robotworld-continued__/data-final-fixes.lua:7: SRC: 5kJMATCHED: 5kJ
   4.309 Script @__robotworld-continued__/data-final-fixes.lua:7: SRC: 0.05kJMATCHED: 05kJ