### PR TITLE
Remove trailing space on filename. (failing on linux)

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -254,7 +254,7 @@ if (settings.startup["enable-early-logistic-robots"].value or settings.startup["
       type = "technology",
       name = "early-character-logistic-slots",
       icon_size = 128,
-      icon = "__base__/graphics/technology/logistic-robotics.png ",
+      icon = "__base__/graphics/technology/logistic-robotics.png",
       effects =
       {
         {
@@ -281,7 +281,7 @@ if (settings.startup["enable-early-logistic-robots"].value or settings.startup["
       type = "technology",
       name = "early-character-logistic-trash-slots",
       icon_size = 128,
-      icon = "__base__/graphics/technology/logistic-robotics.png ",
+      icon = "__base__/graphics/technology/logistic-robotics.png",
       effects =
       {
         {


### PR DESCRIPTION
This was failing on my machine but I run on linux /shrug :D 